### PR TITLE
chore: update organisation PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 https://montugroup.atlassian.net/browse/CHANGEME
 
 _In a few points, summarise the changes being made. Consider including testing
-steps/evidence, screenshots and related feature flags. For more info 👉 [PR standards](https://montugroup.atlassian.net/wiki/x/BYDiFw)_
+steps/evidence, screenshots and related feature flags. For more info 👉 [code review standards](https://montugroup.atlassian.net/wiki/x/BYDiFw)_
 
 ## Checklist
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 https://montugroup.atlassian.net/browse/CHANGEME
 
 _In a few points, summarise the changes being made. Consider including testing
-steps/evidence, screenshots and related feature flags._
+steps/evidence, screenshots and related feature flags. For more info 👉 [PR standards](https://montugroup.atlassian.net/wiki/x/BYDiFw)_
 
 ## Checklist
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,8 +2,8 @@
 
 https://montugroup.atlassian.net/browse/CHANGEME
 
-_In a few points, summarise the changes being made. Consider including screenshots, testing
-steps/evidence._
+_In a few points, summarise the changes being made. Consider including testing
+steps/evidence, screenshots and related feature flags._
 
 ## Checklist
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,9 @@
 ## What has changed?
 
-https://montugroup.atlassian.net/browse/CHANGEME
-
 _In a few points, summarise the changes being made. Consider including testing
 steps/evidence, screenshots and related feature flags. For more info 👉 [code review standards](https://montugroup.atlassian.net/wiki/x/BYDiFw)_
+
+Jira Ticket: https://montugroup.atlassian.net/browse/CHANGEME
 
 ## Checklist
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,63 +1,12 @@
-## Description
-<!---
-Example:
+## What has changed?
 
-Feature to add the ability to create orders starting with "example:" title
--->
+https://montugroup.atlassian.net/browse/CHANGEME
 
-Put your description here...
+_In a few points, summarise the changes being made. Consider including screenshots, testing
+steps/evidence._
 
-## Jira task
-[CHANGE_ME](https://montugroup.atlassian.net/browse/JIRA_TASK)
+## Checklist
 
-## Feature flag
-<!---
-Example:
-Changes are behind the 'example_feature_flag' feature flag, which is currently set to OFF
--->
-
-## Type of change
-<!---
-Example:
-
-build: build system changes or external dependencies.
-chore: General maintenance tasks, updates, upgrades.
-ci: Continuous integration (CI) configuration or scripts.
-docs: Adding or updating documentation files.
-feat: Used for new feature additions or significant enhancements.
-fix: Used for bug fixes or resolving issues.
-perf: Improving performance, such as optimizing algorithms or code.
-refactor: Refactor of previous code that does not introduce new features or fix bugs.
-revert: Reverting a previous commit, no new changes.
-style: Code style changes, such as formatting, indentation, or whitespace.
-test: Adding, modifying, or enhancing tests.
--->
-
-Put one of the above here...
-
-## How to verify the changes:
-<!---
-Example:
-
-1. Have example-service running with changes from Pull-Request #420
-2. Log in as an example user
-3. Go to the Examples page
-4. Click on the "New example" button
-5. Fill in the form
-6. Click on the "Submit" button
-7. Verify that the example is created
-8. Verify that the example is displayed in the Examples list with new title starting with "example:"
--->
-
-Put your verification steps here...
-
-## Screenshots (For all UI changes):
-<!---
-Example:
-
-| Before          | After            |
-|-----------------|------------------|
-| ![](image_here) | ![](image_here)  |
--->
-
-Put your screenshots here...
+- [ ] I have performed a self-review of my code
+- [ ] I have added adequate test coverage
+- [ ] I have considered performance and security implications


### PR DESCRIPTION
## What has changed?

Updates the MontuGroup PR template to align more to what has been adopted in MGS and montu-web with a slight change putting the emphasis on "What has changed?", this ensures it's the first we see on the PR, when a link is unfurled and on squash commit messages

Keeping the checklist as it's a simple measure to encourage accountability of the changes being made

We still encourage screenshots, testing evidence, feature flags etc. just without dedicated sections that can add unnecessary bloat to our squash commits

This template serves as a baseline for repos and can be extended upon to meet individual repo needs

Jira Ticket: https://montugroup.atlassian.net/browse/MA-234

## Checklist
- [x] I have performed a self-review of my code
- [ ] I have added adequate test coverage
- [ ] I have considered performance and security implications